### PR TITLE
Implement missing methods in ClickHouse adapter and driver

### DIFF
--- a/src/Driver/ClickHouseObjectDriver.php
+++ b/src/Driver/ClickHouseObjectDriver.php
@@ -7,26 +7,109 @@ use RuntimeException;
 
 class ClickHouseObjectDriver extends AbstractObjectDriver
 {
+    /**
+     * Quote table name for ClickHouse.
+     * ClickHouse uses backticks for identifiers with special characters.
+     *
+     * @param string $name
+     * @return string
+     */
     public function quoteTableName(string $name): string
     {
-        return $name;
+        // Handle database.table notation
+        if (strpos($name, '.') !== false) {
+            $parts = explode('.', $name, 2);
+            return '`' . $parts[0] . '`.`' . $parts[1] . '`';
+        }
+
+        return '`' . $name . '`';
     }
-    
+
+    /**
+     * Quote column name for ClickHouse.
+     * ClickHouse uses backticks for identifiers with special characters.
+     *
+     * @param string $name
+     * @return string
+     */
     public function quoteColumnName(string $name): string
     {
+        $name = '`' . $name . '`';
+
+        // Handle table.column notation
+        if (strpos($name, '.') !== false) {
+            $name = str_replace('.', '`.`', $name);
+            $keys = explode('.', $name);
+
+            // Handle wildcard selector (table.*)
+            if (isset($keys[1]) && $keys[1] === '`*`') {
+                $keys[1] = trim($keys[1], '`');
+                $name = implode('.', $keys);
+            }
+        }
+
         return $name;
     }
     
+    /**
+     * Get table indexes from ClickHouse system tables.
+     * Returns information about primary keys and sorting keys.
+     *
+     * @param DataAccessObjectInterface $object
+     * @param string $tableName
+     * @return array
+     */
     public function getTableIndexes(DataAccessObjectInterface $object, string $tableName): array
     {
-        // TODO: Implement getTableIndexes() method.
+        $sql = "SELECT
+                    name,
+                    engine,
+                    primary_key,
+                    sorting_key,
+                    partition_key
+                FROM system.tables
+                WHERE name = " . $object->quote($tableName) . "
+                AND database = currentDatabase()";
+
+        $result = $object->getAll($sql)->toNative();
+
+        // Also get data skipping indexes
+        $skipIndexSql = "SELECT
+                            name,
+                            type,
+                            expr
+                         FROM system.data_skipping_indices
+                         WHERE table = " . $object->quote($tableName) . "
+                         AND database = currentDatabase()";
+
+        $skipIndexes = $object->getAll($skipIndexSql)->toNative();
+
+        return [
+            'table_info' => $result,
+            'data_skipping_indexes' => $skipIndexes
+        ];
     }
-    
+
+    /**
+     * ClickHouse does not support foreign key constraints.
+     * This method is kept for interface compatibility but does nothing.
+     *
+     * @param DataAccessObjectInterface $object
+     * @param bool $isEnable
+     * @return void
+     */
     public function setForeignKeyChecks(DataAccessObjectInterface $object, bool $isEnable = true)
     {
-        // TODO: Implement setForeignKeyChecks() method.
+        // ClickHouse does not support foreign key constraints
+        // This method does nothing but maintains interface compatibility
     }
-    
+
+    /**
+     * Get list of tables in the current database.
+     *
+     * @param DataAccessObjectInterface $object
+     * @return array
+     */
     public function getTables(DataAccessObjectInterface $object): array
     {
         return $object->getCol("SHOW TABLES")->toNative();

--- a/src/ObjectClickHouseAdapter.php
+++ b/src/ObjectClickHouseAdapter.php
@@ -89,19 +89,41 @@ class ObjectClickHouseAdapter extends ObjectAdapter
         return new ArrayLiteral($result);
     }
     
+    /**
+     * ClickHouse does not support traditional ACID transactions.
+     * This method is kept for interface compatibility but does nothing.
+     *
+     * @param bool $isolationLevel
+     * @return void
+     */
     public function begin(bool $isolationLevel = false)
     {
-        // TODO: Implement begin() method.
+        // ClickHouse does not support transactions in the traditional sense
+        // Operations are atomic at the block level
     }
-    
+
+    /**
+     * ClickHouse does not support traditional ACID transactions.
+     * This method is kept for interface compatibility but does nothing.
+     *
+     * @return void
+     */
     public function commit()
     {
-        // TODO: Implement commit() method.
+        // ClickHouse does not support transactions in the traditional sense
+        // Operations are atomic at the block level
     }
-    
+
+    /**
+     * ClickHouse does not support traditional ACID transactions.
+     * This method is kept for interface compatibility but does nothing.
+     *
+     * @return void
+     */
     public function rollback()
     {
-        // TODO: Implement rollback() method.
+        // ClickHouse does not support transactions in the traditional sense
+        // Operations are atomic at the block level
     }
     
     public function query(string $sql): int
@@ -121,11 +143,50 @@ class ObjectClickHouseAdapter extends ObjectAdapter
         return $this->db->insertAssocBulk($table, $values)->count();
     }
     
+    /**
+     * ClickHouse does not support auto-increment IDs in the traditional sense.
+     * This method returns 0 for interface compatibility.
+     *
+     * Note: ClickHouse tables typically use UInt64 or other types for IDs,
+     * and ID generation should be handled at the application level.
+     *
+     * @return int Always returns 0
+     */
     public function getInsertID(): int
     {
-        // TODO: Implement getInsertID() method.
+        return 0;
     }
     
+    /**
+     * Update rows in ClickHouse using ALTER TABLE ... UPDATE mutation.
+     *
+     * Note: ClickHouse UPDATE is asynchronous and uses mutations.
+     * The operation is not immediate and depends on merge operations.
+     * For real-time updates, consider using ReplacingMergeTree or other strategies.
+     *
+     * @param string $table
+     * @param array $values
+     * @param array $condition
+     * @return int Number of affected rows (always returns 0 for ClickHouse)
+     */
+    public function update(string $table, array $values, array $condition = []): int
+    {
+        $values = $this->getUpdateValues($values);
+
+        $sql = "ALTER TABLE ".$table." UPDATE ".implode(", ", $values);
+
+        if (is_array($condition)) {
+            $sqlCondition = $this->getSqlCondition($condition);
+            if ($sqlCondition) {
+                $sql .= sprintf(static::SQL_WHERE, implode(static::SQL_AND, $sqlCondition));
+            }
+        } else {
+            $sql .= sprintf(static::SQL_WHERE, $condition);
+        }
+
+        return $this->query($sql);
+    }
+
     public function getDatabaseType(): string
     {
         return "ClickHouse";


### PR DESCRIPTION
ObjectClickHouseAdapter changes:
- Implement transaction methods (begin, commit, rollback) with proper documentation explaining ClickHouse's block-level atomicity instead of traditional transactions
- Implement getInsertID() method returning 0 (ClickHouse doesn't support auto-increment)
- Implement update() method using ALTER TABLE ... UPDATE mutation syntax with documentation about asynchronous nature of mutations

ClickHouseObjectDriver changes:
- Improve quoteTableName() to add backticks and support database.table notation
- Improve quoteColumnName() to add backticks and support table.column notation
- Implement getTableIndexes() to query system.tables for primary keys, sorting keys, partition keys, and data skipping indexes
- Implement setForeignKeyChecks() as no-op (ClickHouse doesn't support foreign keys)

All changes maintain interface compatibility while respecting ClickHouse's unique characteristics and limitations.